### PR TITLE
Don't pass Unicode strings to File::Spec->rel2abs()

### DIFF
--- a/lib/XML/TreeBuilder.pm
+++ b/lib/XML/TreeBuilder.pm
@@ -11,6 +11,7 @@ use IO::File;
 use XML::Catalog 1.02;
 use File::Basename;
 use File::Spec;
+use Encode qw(encode_utf8);
 use vars qw(@ISA $VERSION);
 
 $VERSION = '5.4';
@@ -239,6 +240,8 @@ sub new {
                     else {
                         my ( $filename, $directories, $suffix )
                             = fileparse($base);
+                        $sysid = encode_utf8($sysid) if utf8::is_utf8($sysid);
+                        $directories = encode_utf8($directories) if utf8::is_utf8($directories);
                         $file = File::Spec->rel2abs( $sysid, $directories );
                     }
                 }


### PR DESCRIPTION
Otherwise the resulting filename has the non-ASCII characters
double-encoded in UTF-8 (and will not work). Filenames don't have
any associated character set and should thus always be treated as bytes.

See https://bugzilla.redhat.com/show_bug.cgi?id=1171670 for a discussion
of this problem in the context of Publican.

Signed-off-by: Raphaël Hertzog <hertzog@debian.org>